### PR TITLE
[feature] Add z.ai provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <img src="public/icon-128.png" alt="ApiBeam Logo" width="128" height="128" />
   <h1>ApiBeam</h1>
-  <p><strong>Convert your ChatGPT or Claude account into an API</strong></p>
-  <p>A Chrome/Firefox extension that bridges your ChatGPT or Claude account to your applications through a simple REST API</p>
+  <p><strong>Convert your ChatGPT, Claude, or z.ai account into an API</strong></p>
+  <p>A Chrome/Firefox extension that bridges your ChatGPT, Claude, or z.ai account to your applications through a simple REST API</p>
 </div>
 
 ---
@@ -12,21 +12,21 @@ https://github.com/user-attachments/assets/6543dbb2-d9ef-4d06-84cf-578e2283d074
 
 ## 🚀 Overview
 
-ApiBeam is a powerful browser extension that transforms your ChatGPT or Claude account into a programmatic API. Instead of manually interacting with ChatGPT/Claude through the web interface, ApiBeam allows you to:
+ApiBeam is a powerful browser extension that transforms your ChatGPT, Claude, or z.ai account into a programmatic API. Instead of manually interacting with these web interfaces, ApiBeam allows you to:
 
-- Send API requests from your applications to your ChatGPT or Claude account
+- Send API requests from your applications to your ChatGPT, Claude, or z.ai account
 - Receive structured responses in JSON format
 - Configure language-specific prompts for consistent API-like responses
-- Switch between ChatGPT and Claude providers with a single click
+- Switch between ChatGPT, Claude, and z.ai providers with a single click
 - Maintain full control of your data (everything runs locally on your machine)
 
-**Perfect for**: Developers who want to use ChatGPT or Claude as a backend service without API costs or API keys.
+**Perfect for**: Developers who want to use ChatGPT, Claude, or z.ai as a backend service without API costs or API keys.
 
 ---
 
 ## ✨ Features
 
-- 🔌 **Simple REST API** - Access ChatGPT via HTTP requests
+- 🔌 **Simple REST API** - Access ChatGPT, Claude, or z.ai via HTTP requests
 - 🌍 **Cross-Browser Support** - Works on Chrome and Firefox (Manifest V3)
 - ⚡ **Real-time WebSocket Connection** - Low-latency server-to-extension communication
 - 🔒 **Local & Private** - All data stays on your machine, no third-party servers
@@ -42,7 +42,7 @@ ApiBeam is a powerful browser extension that transforms your ChatGPT or Claude a
 - Node.js >= 18.17.1
 - npm or yarn
 - Chrome or Firefox browser
-- Active ChatGPT account and/or Claude account
+- Active ChatGPT, Claude, and/or z.ai account
 
 ---
 
@@ -125,7 +125,7 @@ ApiBeam Server (Middleware)
     ↓
 Chrome Extension (Running on Your Computer)
     ↓
-ChatGPT Web Interface
+ChatGPT / Claude / z.ai Web Interface
     ↓
 Response travels back through the same chain
 ```
@@ -134,8 +134,8 @@ Response travels back through the same chain
 
 1. **Your Application** sends an HTTP request to the ApiBeam server with a prompt
 2. **ApiBeam Server** receives the request and broadcasts it via WebSocket
-3. **Chrome Extension** receives the message and injects it into ChatGPT
-4. **ChatGPT** processes the request and returns a response
+3. **Chrome Extension** receives the message and injects it into your AI provider (ChatGPT, Claude, or z.ai)
+4. **The provider** processes the request and returns a response
 5. **Extension** captures the response stream and sends it back through WebSocket
 6. **Server** returns the structured response to your application
 
@@ -275,12 +275,19 @@ That's it — the extension will now route all requests through your own server.
 - Ensure ChatGPT is fully loaded
 - Check browser console for errors
 
+### Claude / z.ai Detection Failed
+
+**Problem**: Extension can't find the Claude or z.ai input field
+- **Solution**: Make sure you're on `https://claude.ai` or `https://chat.z.ai`
+- Ensure the page is fully loaded
+- Check browser console for errors
+
 ### Response Parsing Errors
 
 **Problem**: Responses are incomplete or malformed
 - **Solution**: Verify your language and method configuration
 - Check that your prompt is valid
-- Review ChatGPT's response format
+- Review the provider's response format
 
 ### Network Speed Shows "Calculating..."
 
@@ -297,7 +304,11 @@ apibeam/
 ├── src/
 │   ├── pages/
 │   │   ├── background/       # Background service worker
-│   │   ├── content/          # Content script (runs on ChatGPT)
+│   │   ├── content/          # Content scripts (ChatGPT, Claude, z.ai)
+│   │   │   └── components/
+│   │   │       ├── chatgpt/  # ChatGPT provider integration
+│   │   │       ├── claude/   # Claude provider integration
+│   │   │       └── zai/      # z.ai provider integration
 │   │   ├── popup/            # Extension popup UI
 │   │   └── settings/         # Settings page
 │   ├── locales/              # i18n translations

--- a/manifest.dev.json
+++ b/manifest.dev.json
@@ -22,6 +22,10 @@
     {
       "resources": ["loader-claude.js"],
       "matches": ["https://claude.ai/*"]
+    },
+    {
+      "resources": ["loader-zai.js"],
+      "matches": ["https://chat.z.ai/*", "https://*.chat.z.ai/*"]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,11 @@
       "matches": ["https://claude.ai/*"],
       "js": ["src/pages/content/claude-index.tsx"],
       "css": ["contentStyle.css"]
+    },
+    {
+      "matches": ["https://chat.z.ai/*"],
+      "js": ["src/pages/content/zai-index.tsx"],
+      "css": ["contentStyle.css"]
     }
   ],
   "web_accessible_resources": [
@@ -40,6 +45,10 @@
     {
       "resources": ["loader-claude.js"],
       "matches": ["https://claude.ai/*"]
+    },
+    {
+      "resources": ["loader-zai.js"],
+      "matches": ["https://chat.z.ai/*"]
     },
     {
       "resources": ["src/pages/settings/index.html"],

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -5,8 +5,9 @@ import type { Socket } from "socket.io-client";
 export const DEFAULT_API_BASE_URL = "https://apibeam.bitsmall.in/";
 const chatgptBaseUrl = "https://chatgpt.com";
 const claudeBaseUrl = "https://claude.ai/new";
+const zaiBaseUrl = "https://chat.z.ai";
 
-export type Provider = 'chatgpt' | 'claude';
+export type Provider = 'chatgpt' | 'claude' | 'zai';
 
 export type SettingsSchema = {
   language: string;
@@ -69,7 +70,9 @@ const getProvider = async (): Promise<Provider> => {
 
 const getProviderUrl = async (): Promise<string> => {
   const provider = await getProvider();
-  return provider === "claude" ? claudeBaseUrl : chatgptBaseUrl;
+  if (provider === "claude") return claudeBaseUrl;
+  if (provider === "zai") return zaiBaseUrl;
+  return chatgptBaseUrl;
 };
 
 const getConnectUrl = async () => {

--- a/src/pages/content/components/zai/index.tsx
+++ b/src/pages/content/components/zai/index.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect } from 'react';
+import { useMessageHandler } from '../../shared/useMessageHandler';
+
+const waitForElement = (selector: string, timeout = 10000): Promise<Element | null> =>
+  new Promise((resolve) => {
+    const el = document.querySelector(selector);
+    if (el) return resolve(el);
+    const observer = new MutationObserver(() => {
+      const found = document.querySelector(selector);
+      if (found) {
+        observer.disconnect();
+        resolve(found);
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    setTimeout(() => { observer.disconnect(); resolve(null); }, timeout);
+  });
+
+export const Zai = () => {
+  const sendToChat = useCallback(
+    async (content: { route: string; body: object }, prompt: string) => {
+      const editor = await waitForElement('#chat-input') as HTMLTextAreaElement;
+
+      if (!editor) {
+        console.error('[ApiBeam z.ai] Could not find z.ai input textarea');
+        return;
+      }
+
+      const text = `${prompt ? prompt + '\n' : ''}Route: ${content.route}\nPayload: ${JSON.stringify(content.body)}`;
+
+      editor.focus();
+
+      // Set value using native input setter to trigger React/Svelte change detection
+      const nativeSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        'value'
+      )?.set;
+      if (nativeSetter) {
+        nativeSetter.call(editor, text);
+      } else {
+        editor.value = text;
+      }
+      editor.dispatchEvent(new Event('input', { bubbles: true }));
+
+      window.setTimeout(async () => {
+        const sendBtn =
+          (document.querySelector('#send-message-button') as HTMLButtonElement) ??
+          (document.querySelector('button[type="submit"]') as HTMLButtonElement);
+        if (sendBtn && !sendBtn.disabled) {
+          sendBtn.click();
+        } else {
+          console.warn('[ApiBeam z.ai] Send button not found or disabled');
+        }
+      }, 200);
+    },
+    []
+  );
+
+  const runLastScript = (json: object) => {
+    if (json) {
+      chrome.runtime.sendMessage({ type: 'question_answer', content: json });
+    }
+  };
+
+  useMessageHandler(sendToChat);
+
+  useEffect(() => {
+    const newScript = document.createElement('script');
+    newScript.src = chrome.runtime.getURL('loader-zai.js');
+    document.body.appendChild(newScript);
+    newScript.onload = () => {
+      window.addEventListener('message', (event) => {
+        if (event.source !== window) return;
+        const { data } = event.data || {};
+        runLastScript(data);
+      });
+    };
+  }, []);
+
+  return <div />;
+};

--- a/src/pages/content/components/zai/loader.ts
+++ b/src/pages/content/components/zai/loader.ts
@@ -1,0 +1,90 @@
+// z.ai SSE fetch interceptor -- injected into chat.z.ai page world
+// z.ai SSE format (standard "data:" prefix):
+//   data: {"type":"chat:completion","data":{"delta_content":"...","phase":"thinking"}}
+//   data: {"type":"chat:completion","data":{"delta_content":"...","phase":"answer"}}
+//   data: {"type":"chat:completion","data":{"phase":"done","done":true}}
+(function () {
+  const originalFetch = window.fetch;
+
+  window.fetch = async function (...args) {
+    const response = await originalFetch(...args);
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/event-stream')) {
+      return response;
+    }
+
+    const clone = response.clone();
+    const reader = clone.body?.getReader();
+    const decoder = new TextDecoder('utf-8');
+
+    let buffer = '';
+    let fullAssistantMessage = '';
+
+    async function readStream() {
+      while (true) {
+        if (!reader) return;
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Split by double newline (SSE event separator)
+        const parts = buffer.split(/\r?\n\r?\n/);
+        buffer = parts.pop() as string;
+
+        for (let part of parts) {
+          part = part.trim();
+          if (!part) continue;
+
+          // Standard SSE: lines start with "data:"
+          const lines = part.split(/\r?\n/);
+          for (const line of lines) {
+            if (!line.startsWith('data:')) continue;
+            const dataStr = line.substring(5).trim(); // 'data:'.length === 5
+            if (dataStr === '[DONE]') continue;
+
+            try {
+              const obj = JSON.parse(dataStr);
+
+              // z.ai format: { type: "chat:completion", data: { delta_content: "...", phase: "..." } }
+              if (obj.type === 'chat:completion' && obj.data) {
+                // Only collect content from answer phase (skip thinking)
+                if (typeof obj.data.delta_content === 'string' && obj.data.phase === 'answer') {
+                  fullAssistantMessage += obj.data.delta_content;
+                }
+                // If phase is "done", stream is complete
+                if (obj.data.phase === 'done' || obj.data.done === true) {
+                  console.log('[ApiBeam z.ai] Stream complete');
+                }
+              }
+            } catch {
+              // skip non-JSON lines
+            }
+          }
+        }
+      }
+
+      console.log('[ApiBeam z.ai] Captured response:', fullAssistantMessage.substring(0, 200));
+
+      function extractAndParseJson(str: string, fallback: any = null) {
+        if (typeof str !== 'string') return fallback;
+        const jsonMatch = str.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) return fallback;
+        try {
+          return JSON.parse(jsonMatch[0]);
+        } catch {
+          return fallback;
+        }
+      }
+
+      window.postMessage(
+        { data: extractAndParseJson(fullAssistantMessage) },
+        '*'
+      );
+    }
+
+    readStream().catch((err) => console.error('[ApiBeam z.ai] SSE read error:', err));
+    return response;
+  };
+})();

--- a/src/pages/content/components/zai/loader.ts
+++ b/src/pages/content/components/zai/loader.ts
@@ -49,8 +49,8 @@
 
               // z.ai format: { type: "chat:completion", data: { delta_content: "...", phase: "..." } }
               if (obj.type === 'chat:completion' && obj.data) {
-                // Only collect content from answer phase (skip thinking)
-                if (typeof obj.data.delta_content === 'string' && obj.data.phase === 'answer') {
+                // Collect deltas from any phase so we never miss the answer
+                if (typeof obj.data.delta_content === 'string') {
                   fullAssistantMessage += obj.data.delta_content;
                 }
                 // If phase is "done", stream is complete
@@ -78,8 +78,9 @@
         }
       }
 
+      const parsed = extractAndParseJson(fullAssistantMessage);
       window.postMessage(
-        { data: extractAndParseJson(fullAssistantMessage) },
+        { data: parsed ?? fullAssistantMessage },
         '*'
       );
     }

--- a/src/pages/content/zai-index.tsx
+++ b/src/pages/content/zai-index.tsx
@@ -1,0 +1,14 @@
+import { createRoot } from 'react-dom/client';
+import { Zai } from './components/zai';
+import './style.css';
+
+console.log('[ApiBeam] z.ai content script loaded');
+
+const div = document.createElement('div');
+div.id = '__root_zai';
+document.body.appendChild(div);
+
+const rootContainer = document.querySelector('#__root_zai');
+if (!rootContainer) throw new Error("Can't find z.ai root element");
+const root = createRoot(rootContainer);
+root.render(<Zai />);

--- a/src/pages/settings/components/CustomSettingsModal.tsx
+++ b/src/pages/settings/components/CustomSettingsModal.tsx
@@ -66,6 +66,7 @@ export const CustomSettingsModal = ({ apiBaseUrl, onSave, onReset, onClose }: Pr
               [
                 { id: "chatgpt", label: "ChatGPT", icon: "🤖", sublabel: "chat.openai.com" },
                 { id: "claude", label: "Claude", icon: "🟣", sublabel: "claude.ai" },
+                { id: "zai", label: "z.ai", icon: "🔵", sublabel: "chat.z.ai" },
               ] as { id: Provider; label: string; icon: string; sublabel: string }[]
             ).map(({ id, label, icon, sublabel }) => (
               <button

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -44,6 +44,7 @@ export default defineConfig({
       input: {
         loader: resolve(__dirname, "src/pages/content/loader.ts"),
         "loader-claude": resolve(__dirname, "src/pages/content/components/claude/loader.ts"),
+        "loader-zai": resolve(__dirname, "src/pages/content/components/zai/loader.ts"),
         settingsHtml: resolve(__dirname, "src/pages/settings/index.html"),
       },
       output: {


### PR DESCRIPTION
## Summary

Adds [z.ai](https://chat.z.ai) as a third AI provider alongside ChatGPT and Claude.

## Changes

- **`src/pages/background/index.ts`**: add `zai` to the `Provider` union and route it
  to `https://chat.z.ai` in `getProviderUrl`.
- **`src/pages/content/components/zai/loader.ts`** (new): page-world SSE fetch
  interceptor that captures z.ai's `chat:completion` event stream, collects
  `delta_content` from the `answer` phase, parses the JSON payload, and posts it back
  via `window.postMessage`.
- **`src/pages/content/components/zai/index.tsx`** (new): content-script React
  component that injects the loader, fills the `#chat-input` textarea, and clicks send.
- **`src/pages/content/zai-index.tsx`** (new): entry point matching the existing
  `claude-index.tsx` pattern.
- **`manifest.json` / `manifest.dev.json`**: register the `zai-index.tsx` content
  script and the `loader-zai.js` web-accessible resource for `chat.z.ai`.
- **`vite.config.base.ts`**: add `loader-zai` as a Rollup input.
- **`src/pages/settings/components/CustomSettingsModal.tsx`**: add z.ai to the provider
  selector.
- **`README.md`**: document z.ai support across overview, features, requirements,
  troubleshooting, and project structure.

## Testing

- `vite build` for Chrome succeeds.